### PR TITLE
feature/tree-indentation add indentation when the node has no children

### DIFF
--- a/src/components/general/Tree/styles.js
+++ b/src/components/general/Tree/styles.js
@@ -35,6 +35,7 @@ export default (theme) => ({
         },
     },
     empty: {
+        'margin-left': '20px',
         '& $nodeIcon': {
             display: 'none',
         },

--- a/src/components/general/Tree/styles.js
+++ b/src/components/general/Tree/styles.js
@@ -35,7 +35,7 @@ export default (theme) => ({
         },
     },
     empty: {
-        'margin-left': '20px',
+        marginLeft: 20,
         '& $nodeIcon': {
             display: 'none',
         },


### PR DESCRIPTION
Add indentation when the node has no children, so the parent and the children text, won't be aligned vertically and the hierarchy will be more evident.