### PR TITLE
Renamed props and modified hint prop types verification

### DIFF
--- a/src/components/forms/DatePicker/index.jsx
+++ b/src/components/forms/DatePicker/index.jsx
@@ -257,7 +257,7 @@ DatePicker.propTypes = {
     labelMode: PropTypes.oneOf(['horizontal', 'vertical']),
     isFullWidth: PropTypes.bool,
     /** Info popover */
-    hint: PropTypes.string,
+    hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** Error will be displayed below the component with style changes */
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     /** Info will be displayed below the component with style changes */

--- a/src/components/forms/Form/__snapshots__/form.spec.jsx.snap
+++ b/src/components/forms/Form/__snapshots__/form.spec.jsx.snap
@@ -3690,7 +3690,6 @@ exports[`Form complete match 1`] = `
                         isReadOnly={false}
                         label="Employment status"
                         labelMode="horizontal"
-                        mode="vertical"
                         name="employmentStatus"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -3712,6 +3711,7 @@ exports[`Form complete match 1`] = `
                             },
                           ]
                         }
+                        orientation="vertical"
                         overrides={Object {}}
                         type="radioGroup"
                         value={null}

--- a/src/components/forms/Form/index.jsx
+++ b/src/components/forms/Form/index.jsx
@@ -20,7 +20,7 @@ function Form({
     errors,
     customFields,
     useNativeForm,
-    fieldMode,
+    orientation,
     ...props
 }) {
     // Overrides
@@ -96,7 +96,7 @@ function Form({
             title={section.title}
             className={section.className}
             isExpandable={section.isExpandable}
-            fieldMode={fieldMode}
+            orientation={orientation}
             {...override.Section}
         >
             {section.fields.map((field) => {
@@ -189,7 +189,7 @@ Form.propTypes = {
             ),
         }),
     ).isRequired,
-    fieldMode: PropTypes.string,
+    orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 };
 
 export default React.memo(Form);

--- a/src/components/forms/Label/index.jsx
+++ b/src/components/forms/Label/index.jsx
@@ -65,7 +65,7 @@ Text.propTypes = {
     className: PropTypes.string,
     overrides: PropTypes.object,
     isRequired: PropTypes.bool,
-    hint: PropTypes.string,
+    hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };
 
 export default React.memo(Label);

--- a/src/components/forms/Multiplier/MultiplierControl.jsx
+++ b/src/components/forms/Multiplier/MultiplierControl.jsx
@@ -28,7 +28,7 @@ function MultiplierControl({
     onBlur,
     onRemove,
     removeIconClassName,
-    fieldMode,
+    orientation,
     ...props
 }) {
     const classes = useClasses(useStyles, classesProp);
@@ -65,7 +65,7 @@ function MultiplierControl({
                 {...override.Form}
                 override={override.Form}
                 useNativeForm={false}
-                fieldMode={fieldMode}
+                orientation={orientation}
             />
         );
     } else if (type === 'field') {
@@ -122,7 +122,7 @@ MultiplierControl.propTypes = {
     values: PropTypes.any,
     errors: PropTypes.any,
     multiplierItemClassNames: PropTypes.any,
-    fieldMode: PropTypes.string,
+    orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 };
 
 export default React.memo(MultiplierControl);

--- a/src/components/forms/Multiplier/index.jsx
+++ b/src/components/forms/Multiplier/index.jsx
@@ -28,7 +28,7 @@ function Multiplier({
     onBlur,
     labelMode,
     customFields,
-    fieldMode,
+    orientation,
     ...props
 }) {
     const classes = useClasses(useStyles, classesProp);
@@ -47,7 +47,7 @@ function Multiplier({
     const multiplierItemClassNames = classnames(classes.item, {
         [classes.separator]: separator,
         [classes.singleItem]: !Array.isArray(schema),
-        [classes.fieldModeHorizontal]: fieldMode && fieldMode === 'horizontal',
+        [classes.horizontal]: orientation && orientation === 'horizontal',
     });
 
     const rootProps = {
@@ -104,7 +104,7 @@ function Multiplier({
                 {...override.multiplierControl}
                 overrides={override}
                 removeIconClassName={classes.removeIcon}
-                fieldMode={fieldMode}
+                orientation={orientation}
             />,
         );
     }
@@ -163,7 +163,7 @@ Multiplier.propTypes = {
             name: PropTypes.string,
             type: PropTypes.string,
             placeholder: PropTypes.string,
-            hint: PropTypes.string,
+            hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
             isRequired: PropTypes.bool,
             isReadOnly: PropTypes.bool,
             attrs: PropTypes.object,
@@ -178,7 +178,7 @@ Multiplier.propTypes = {
     isFullWidth: PropTypes.bool,
     isReadOnly: PropTypes.bool,
     customFields: PropTypes.object,
-    fieldMode: PropTypes.string,
+    orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 };
 
 export default React.memo(Multiplier);

--- a/src/components/forms/Multiplier/styles.js
+++ b/src/components/forms/Multiplier/styles.js
@@ -64,7 +64,7 @@ export default (theme) => ({
                 padding: 0,
             },
         },
-        '& $fieldModeHorizontal': {
+        '& $horizontal': {
             '&:first-child': {
                 '& $removeIcon': { marginTop: 44 },
             },
@@ -86,7 +86,7 @@ export default (theme) => ({
             width: 'auto',
         },
     },
-    fieldModeHorizontal: {
+    horizontal: {
         borderBottom: 'none',
         marginTop: 0,
         justifyContent: 'flex-start',

--- a/src/components/forms/RadioGroup/Readme.md
+++ b/src/components/forms/RadioGroup/Readme.md
@@ -110,7 +110,7 @@ let onChange = (value) => setState({ value });
     options={options}
     onChange={onChange}
     value={state.value}
-    mode="horizontal"
+    orientation="horizontal"
 />;
 ```
 

--- a/src/components/forms/RadioGroup/__snapshots__/radioGroup.spec.jsx.snap
+++ b/src/components/forms/RadioGroup/__snapshots__/radioGroup.spec.jsx.snap
@@ -438,7 +438,6 @@ exports[`RadioGroup default match 1`] = `
         isReadOnly={false}
         label="Lorem ipsum"
         labelMode="horizontal"
-        mode="vertical"
         onChange={[Function]}
         options={
           Array [
@@ -456,6 +455,7 @@ exports[`RadioGroup default match 1`] = `
             },
           ]
         }
+        orientation="vertical"
         overrides={Object {}}
         value={null}
       >
@@ -1106,7 +1106,6 @@ exports[`RadioGroup disabled match 1`] = `
         isReadOnly={true}
         label="Lorem ipsum"
         labelMode="horizontal"
-        mode="vertical"
         onChange={[Function]}
         options={
           Array [
@@ -1124,6 +1123,7 @@ exports[`RadioGroup disabled match 1`] = `
             },
           ]
         }
+        orientation="vertical"
         overrides={Object {}}
         value={null}
       >
@@ -1762,7 +1762,6 @@ exports[`RadioGroup with values match 1`] = `
         isReadOnly={false}
         label="Lorem ipsum"
         labelMode="horizontal"
-        mode="vertical"
         onChange={[Function]}
         options={
           Array [
@@ -1780,6 +1779,7 @@ exports[`RadioGroup with values match 1`] = `
             },
           ]
         }
+        orientation="vertical"
         overrides={Object {}}
         value="lorem2"
       >

--- a/src/components/forms/RadioGroup/index.jsx
+++ b/src/components/forms/RadioGroup/index.jsx
@@ -21,7 +21,7 @@ function RadioGroup({
     value,
     label,
     labelMode,
-    mode,
+    orientation,
     hint,
     isReadOnly,
     isFullWidth,
@@ -37,7 +37,7 @@ function RadioGroup({
         {
             [classes.isReadOnly]: isReadOnly,
             [classes[`${labelMode}Label`]]: labelMode,
-            [classes[mode]]: mode,
+            [classes[orientation]]: orientation,
         },
         classNameProp,
     );
@@ -81,7 +81,7 @@ RadioGroup.overrides = ['root', 'Radio', 'formControl', 'Label'];
 
 RadioGroup.defaultProps = {
     labelMode: 'horizontal',
-    mode: 'vertical',
+    orientation: 'vertical',
     onChange: () => {},
     value: null,
     options: [],
@@ -102,9 +102,9 @@ RadioGroup.propTypes = {
     value: PropTypes.string,
     label: PropTypes.string,
     labelMode: PropTypes.oneOf(['horizontal', 'vertical']),
-    mode: PropTypes.oneOf(['horizontal', 'vertical']),
+    orientation: PropTypes.oneOf(['horizontal', 'vertical']),
     /** Info popover */
-    hint: PropTypes.string,
+    hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     isReadOnly: PropTypes.bool,
     isFullWidth: PropTypes.bool,
 };

--- a/src/components/forms/Section/index.jsx
+++ b/src/components/forms/Section/index.jsx
@@ -24,7 +24,7 @@ const Section = memo(
         defaultOpen,
         onChange,
         activeFields,
-        fieldMode,
+        orientation,
         ...props
     }) => {
         const classes = useClasses(useStyles, classesProp);
@@ -39,7 +39,7 @@ const Section = memo(
         const rootClassName = classnames(
             classes.root,
             {
-                [classes.fieldModeHorizontal]: fieldMode === 'horizontal',
+                [classes.horizontal]: orientation === 'horizontal',
             },
             classNameProp,
         );
@@ -146,7 +146,7 @@ Section.propTypes = {
         Text: PropTypes.object,
         icon: PropTypes.object,
     }),
-    fieldMode: PropTypes.string,
+    orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 };
 
 export default Section;

--- a/src/components/forms/Section/styles.js
+++ b/src/components/forms/Section/styles.js
@@ -100,7 +100,7 @@ export default (theme) => ({
             transform: 'translate(-50%, -50%)',
         },
     },
-    fieldModeHorizontal: {
+    horizontal: {
         display: 'flex',
         margin: '0 -8px',
         padding: 0,

--- a/src/components/forms/Select/index.jsx
+++ b/src/components/forms/Select/index.jsx
@@ -662,7 +662,7 @@ Select.propTypes = {
     loadingPlaceholder: PropTypes.string,
     isFullWidth: PropTypes.bool,
     /** Info popover */
-    hint: PropTypes.string,
+    hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** Error will be displayed below the component with style changes */
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     /** Info will be displayed below the component with style changes */

--- a/src/components/forms/Slider/index.jsx
+++ b/src/components/forms/Slider/index.jsx
@@ -163,7 +163,7 @@ Slider.propTypes = {
     isFullWidth: PropTypes.bool,
     isRange: PropTypes.bool,
     /** Info popover */
-    hint: PropTypes.string,
+    hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** Error will be displayed below the component with style changes */
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     isReadOnly: PropTypes.bool,

--- a/src/components/forms/SwitchInput/index.jsx
+++ b/src/components/forms/SwitchInput/index.jsx
@@ -84,7 +84,7 @@ SwitchInput.propTypes = {
     value: PropTypes.any,
     onChange: PropTypes.func,
     /** Info popover */
-    hint: PropTypes.string,
+    hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** Error will be displayed below the component with style changes */
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     isReadOnly: PropTypes.bool,

--- a/src/components/forms/components/FieldControl/index.jsx
+++ b/src/components/forms/components/FieldControl/index.jsx
@@ -126,7 +126,7 @@ FieldControl.propTypes = {
         name: PropTypes.string,
         type: PropTypes.string,
         placeholder: PropTypes.string,
-        hint: PropTypes.string,
+        hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
         isRequired: PropTypes.bool,
         isReadOnly: PropTypes.bool,
         className: PropTypes.string,

--- a/src/components/forms/components/InputWrapper/index.jsx
+++ b/src/components/forms/components/InputWrapper/index.jsx
@@ -86,7 +86,7 @@ InputWrapper.propTypes = {
     labelMode: PropTypes.oneOf(['horizontal', 'vertical']),
     isFullWidth: PropTypes.bool,
     /** Info popover */
-    hint: PropTypes.string,
+    hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** Error will be displayed below the component with style changes */
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     /** Info will be displayed below the component with style changes */


### PR DESCRIPTION
- Multiplier & RadioGroup: Renamed fieldMode and mode props to "orientation" for coherence.
- Allow node as content in the field label hint's popover.