### PR TITLE
Feature/even more quickfilters feedback

### DIFF
--- a/src/components/forms/Form/__snapshots__/form.spec.jsx.snap
+++ b/src/components/forms/Form/__snapshots__/form.spec.jsx.snap
@@ -2572,6 +2572,7 @@ exports[`Form complete match 1`] = `
                                                     Object {
                                                       "& .hoi-poi-select__search-indicator": Object {
                                                         "alignItems": "center",
+                                                        "alignSelf": "flex-start",
                                                         "display": "flex",
                                                         "height": 34,
                                                         "marginRight": 8,
@@ -2610,7 +2611,7 @@ exports[`Form complete match 1`] = `
                                                   onTouchEnd={[Function]}
                                                 >
                                                   <div
-                                                    className="hoi-poi-select__control css-en49af-control"
+                                                    className="hoi-poi-select__control css-z1h4qh-control"
                                                     onMouseDown={[Function]}
                                                     onTouchEnd={[Function]}
                                                   >
@@ -7124,6 +7125,7 @@ exports[`Form complete match 1`] = `
                                                                         Object {
                                                                           "& .hoi-poi-select__search-indicator": Object {
                                                                             "alignItems": "center",
+                                                                            "alignSelf": "flex-start",
                                                                             "display": "flex",
                                                                             "height": 34,
                                                                             "marginRight": 8,
@@ -7162,7 +7164,7 @@ exports[`Form complete match 1`] = `
                                                                       onTouchEnd={[Function]}
                                                                     >
                                                                       <div
-                                                                        className="hoi-poi-select__control css-en49af-control"
+                                                                        className="hoi-poi-select__control css-z1h4qh-control"
                                                                         onMouseDown={[Function]}
                                                                         onTouchEnd={[Function]}
                                                                       >

--- a/src/components/forms/Multiplier/__snapshots__/multiplier.spec.jsx.snap
+++ b/src/components/forms/Multiplier/__snapshots__/multiplier.spec.jsx.snap
@@ -1720,6 +1720,7 @@ exports[`Multiplier complete match 1`] = `
                                                         Object {
                                                           "& .hoi-poi-select__search-indicator": Object {
                                                             "alignItems": "center",
+                                                            "alignSelf": "flex-start",
                                                             "display": "flex",
                                                             "height": 34,
                                                             "marginRight": 8,
@@ -1758,7 +1759,7 @@ exports[`Multiplier complete match 1`] = `
                                                       onTouchEnd={[Function]}
                                                     >
                                                       <div
-                                                        className="hoi-poi-select__control css-en49af-control"
+                                                        className="hoi-poi-select__control css-z1h4qh-control"
                                                         onMouseDown={[Function]}
                                                         onTouchEnd={[Function]}
                                                       >

--- a/src/components/forms/Select/__snapshots__/select.spec.jsx.snap
+++ b/src/components/forms/Select/__snapshots__/select.spec.jsx.snap
@@ -1481,6 +1481,7 @@ exports[`Select default match 1`] = `
                                     Object {
                                       "& .hoi-poi-select__search-indicator": Object {
                                         "alignItems": "center",
+                                        "alignSelf": "flex-start",
                                         "display": "flex",
                                         "height": 34,
                                         "marginRight": 8,
@@ -1519,7 +1520,7 @@ exports[`Select default match 1`] = `
                                   onTouchEnd={[Function]}
                                 >
                                   <div
-                                    className="hoi-poi-select__control css-en49af-control"
+                                    className="hoi-poi-select__control css-z1h4qh-control"
                                     onMouseDown={[Function]}
                                     onTouchEnd={[Function]}
                                   >
@@ -4795,6 +4796,7 @@ exports[`Select with disabled options match 1`] = `
                                     Object {
                                       "& .hoi-poi-select__search-indicator": Object {
                                         "alignItems": "center",
+                                        "alignSelf": "flex-start",
                                         "display": "flex",
                                         "height": 34,
                                         "marginRight": 8,
@@ -4833,7 +4835,7 @@ exports[`Select with disabled options match 1`] = `
                                   onTouchEnd={[Function]}
                                 >
                                   <div
-                                    className="hoi-poi-select__control css-en49af-control"
+                                    className="hoi-poi-select__control css-z1h4qh-control"
                                     onMouseDown={[Function]}
                                     onTouchEnd={[Function]}
                                   >

--- a/src/components/forms/Select/styles.js
+++ b/src/components/forms/Select/styles.js
@@ -155,7 +155,7 @@ export default (theme) => ({
             width: 14,
             height: 34,
             marginRight: 8,
-            alignSelf: 'flexs-start',
+            alignSelf: 'flex-start',
         },
     },
     controlFocused: {

--- a/src/components/forms/Select/styles.js
+++ b/src/components/forms/Select/styles.js
@@ -155,6 +155,8 @@ export default (theme) => ({
             width: 14,
             height: 34,
             marginRight: 8,
+            display: 'flex',
+            alignItems: 'center',
             alignSelf: 'flex-start',
         },
     },

--- a/src/components/forms/Select/styles.js
+++ b/src/components/forms/Select/styles.js
@@ -155,8 +155,7 @@ export default (theme) => ({
             width: 14,
             height: 34,
             marginRight: 8,
-            display: 'flex',
-            alignItems: 'center',
+            alignSelf: 'flexs-start',
         },
     },
     controlFocused: {

--- a/src/components/general/Breadcrumbs/index.jsx
+++ b/src/components/general/Breadcrumbs/index.jsx
@@ -44,7 +44,7 @@ function Breadcrumbs({
     );
 
     const breadcrumbItems = useMemo(() => {
-        if (!items) return null;
+        if (!items || items.length === 1) return null;
         return items.reduce((arr, item, idx) => {
             if (item) {
                 const isLast = idx === items.length - 1;

--- a/src/components/general/Chip/__snapshots__/chip.spec.jsx.snap
+++ b/src/components/general/Chip/__snapshots__/chip.spec.jsx.snap
@@ -456,10 +456,10 @@ exports[`Chip big size match 1`] = `
               className="HoiPoi__Chip__Text-4-2"
               isTruncated={false}
               overrides={Object {}}
-              type="caption"
+              type="body"
             >
               <span
-                className="HoiPoi__Text__root-4-18 HoiPoi__Chip__Text-4-2 HoiPoi__Text__caption-4-30"
+                className="HoiPoi__Text__root-4-18 HoiPoi__Chip__Text-4-2 HoiPoi__Text__body-4-28"
                 style={Object {}}
               >
                 Lorem ipsum

--- a/src/components/general/Chip/index.jsx
+++ b/src/components/general/Chip/index.jsx
@@ -135,6 +135,15 @@ function Chip({
         override.ReadOnlyIcon,
     ]);
 
+    const textProps = useMemo(
+        () => ({
+            type: size === 'large' ? 'body' : 'caption',
+            className: classes.Text,
+            ...override.Text,
+        }),
+        [classes.Text, override.Text, size],
+    );
+
     return (
         <div
             {...rootProps}
@@ -159,9 +168,7 @@ function Chip({
                         {...override.Avatar}
                     />
                 )}
-                <Text type="caption" className={classes.Text} {...override.Text}>
-                    {children}
-                </Text>
+                <Text {...textProps}>{children}</Text>
                 {icons.length > 0 && (
                     <div className={classes.icons} {...override.icons}>
                         {icons}

--- a/src/components/general/SearchBar/__snapshots__/searchBar.spec.jsx.snap
+++ b/src/components/general/SearchBar/__snapshots__/searchBar.spec.jsx.snap
@@ -1733,6 +1733,7 @@ exports[`SearchBar default match 1`] = `
                                           Object {
                                             "& .hoi-poi-select__search-indicator": Object {
                                               "alignItems": "center",
+                                              "alignSelf": "flex-start",
                                               "display": "flex",
                                               "height": 34,
                                               "marginRight": 8,
@@ -1771,7 +1772,7 @@ exports[`SearchBar default match 1`] = `
                                         onTouchEnd={[Function]}
                                       >
                                         <div
-                                          className="hoi-poi-select__control css-en49af-control"
+                                          className="hoi-poi-select__control css-z1h4qh-control"
                                           onMouseDown={[Function]}
                                           onTouchEnd={[Function]}
                                         >
@@ -3867,6 +3868,7 @@ exports[`SearchBar default match 1`] = `
                                                                         Object {
                                                                           "& .hoi-poi-select__search-indicator": Object {
                                                                             "alignItems": "center",
+                                                                            "alignSelf": "flex-start",
                                                                             "display": "flex",
                                                                             "height": 34,
                                                                             "marginRight": 8,
@@ -3905,7 +3907,7 @@ exports[`SearchBar default match 1`] = `
                                                                       onTouchEnd={[Function]}
                                                                     >
                                                                       <div
-                                                                        className="hoi-poi-select__control css-en49af-control"
+                                                                        className="hoi-poi-select__control css-z1h4qh-control"
                                                                         onMouseDown={[Function]}
                                                                         onTouchEnd={[Function]}
                                                                       >
@@ -7177,6 +7179,7 @@ exports[`SearchBar small match 1`] = `
                                           Object {
                                             "& .hoi-poi-select__search-indicator": Object {
                                               "alignItems": "center",
+                                              "alignSelf": "flex-start",
                                               "display": "flex",
                                               "height": 34,
                                               "marginRight": 8,
@@ -7215,7 +7218,7 @@ exports[`SearchBar small match 1`] = `
                                         onTouchEnd={[Function]}
                                       >
                                         <div
-                                          className="hoi-poi-select__control css-en49af-control"
+                                          className="hoi-poi-select__control css-z1h4qh-control"
                                           onMouseDown={[Function]}
                                           onTouchEnd={[Function]}
                                         >
@@ -9311,6 +9314,7 @@ exports[`SearchBar small match 1`] = `
                                                                         Object {
                                                                           "& .hoi-poi-select__search-indicator": Object {
                                                                             "alignItems": "center",
+                                                                            "alignSelf": "flex-start",
                                                                             "display": "flex",
                                                                             "height": 34,
                                                                             "marginRight": 8,
@@ -9349,7 +9353,7 @@ exports[`SearchBar small match 1`] = `
                                                                       onTouchEnd={[Function]}
                                                                     >
                                                                       <div
-                                                                        className="hoi-poi-select__control css-en49af-control"
+                                                                        className="hoi-poi-select__control css-z1h4qh-control"
                                                                         onMouseDown={[Function]}
                                                                         onTouchEnd={[Function]}
                                                                       >

--- a/src/components/utils/SelectWrapper/styles.js
+++ b/src/components/utils/SelectWrapper/styles.js
@@ -32,7 +32,7 @@ export default (theme) => ({
         ...theme.utils.scrollbar,
         width: '100%',
         maxHeight: 300,
-        padding: '12px 0px',
+        padding: '4px 0px',
         boxSizing: 'border-box',
         overflowY: 'auto',
     },


### PR DESCRIPTION
- Bigger text size in large chips
- Align top the search icon in fuzzy-search select controls
- Revised vertical padding in SelectWrapper popovers
- Hide Breadcrumb if items.length < 2